### PR TITLE
Fix docker builds

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY . /bin
+ENTRYPOINT ["dumb-init"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         tag=docker.pkg.github.com/${{ github.repository }}/${GITHUB_REF##*/}
         echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin docker.pkg.github.com
-        docker build ~/builds -f Dockerfile -t $tag
+        docker build ~/builds -f .github/workflows/Dockerfile -t $tag
         docker push $tag
         rm /home/runner/.docker/config.json # Delete credentials
     - name: Build Finished Webhook

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
-FROM scratch
-COPY . /bin
-ENTRYPOINT ["dumb-init"]
+FROM alpine:latest as dumb-init
+RUN apk add --no-cache build-base git bash
+RUN git clone https://github.com/Yelp/dumb-init.git
+WORKDIR /dumb-init
+RUN make
+
+FROM micro/go-micro
+COPY --from=dumb-init /dumb-init/dumb-init /bin/dumb-init
+RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
+RUN apk upgrade --update git
+COPY entrypoint.sh /
+WORKDIR /
+RUN chmod 755 entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,10 +23,6 @@ git sparse-checkout set $SOURCE
 # go to source
 cd $SOURCE
 
-# Build Binary
-echo "Building Binary"
-time go build -o $SOURCE .
-
 # run the source
 echo "Running service"
-./$SOURCE
+go run .


### PR DESCRIPTION
The micro runtime currently makes use of dockerhub's micro/services image which gets built independently based on this repo. It should continue to function as expected. We do not want to include this step in the GitHub actions because when we drop this workflow template directory in customer monorepos we don't want them to attempt to push to our dockerhub or even theirs for that matter.

DockerHub is still a place for our public builds and the `micro runtime` should be able to pull from there by default. So for that reason I want to preserve the existing state of Dockerfile and entrypoint.sh at the top level.

The GitHub actions Dockerfile moves to .github/workflows/Dockerfile. It will be used in the action itself.

At runtime we can then override the source setting MICRO_RUNTIME_SOURCE=docker.pkg.github.com/micro/services or pass it in and set it as the image.