### PR TITLE
Fix: only run build script with empty arguments when we are in a PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           
           # Only invoke the build script when there are no services added or changed
           # when we are in a PR.
-          if [ -n "{{ $PR_NUMBER }}"] && [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
+          if [ -n "${{ PR_NUMBER }}" ] && [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
             ./build.sh
           else 
             # Build the binaries in the directories which have changed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           
           # Only invoke the build script when there are no services added or changed
           # when we are in a PR.
-          if [ -n "${{ PR_NUMBER }}" ] && [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
+          if [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
             ./build.sh
           else 
             # Build the binaries in the directories which have changed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,6 @@ jobs:
           # Login to docker
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin docker.pkg.github.com
           
-          # Only invoke the build script when there are no services added or changed
-          # when we are in a PR.
           if [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
             ./build.sh
           else 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,10 @@ jobs:
         run: |
           # Login to docker
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin docker.pkg.github.com
-            
-          if [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
+          
+          # Only invoke the build script when there are no services added or changed
+          # when we are in a PR.
+          if [ -n "{{ $PR_NUMBER }}"] && [ -z "${{ steps.services_changed.outputs.services_added }}" ] && [ -z "${{ steps.services_changed.outputs.services_modified }}" ]; then
             ./build.sh
           else 
             # Build the binaries in the directories which have changed

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ export GOARCH=amd64
 
 # Might not always have services passed down -
 # Github Actions needs GITHUB_TOKEN and for PR forks we don't have that.
-if [ -z "$1" ]; then
+if [ -n "$PR_NUMBER" ] && [ -z "$1" ]; then
     echo "Getting files from github api to detect files changed "
     SERVICES=($(find . -name main.go | cut -c 3- | rev | cut -c 9- | rev))
     URL="https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files"

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ export GOARCH=amd64
 
 # Might not always have services passed down -
 # Github Actions needs GITHUB_TOKEN and for PR forks we don't have that.
+# Check for PR number as the pull api call fails if not in a PR obviously.
 if [ -n "$PR_NUMBER" ] && [ -z "$1" ]; then
     echo "Getting files from github api to detect files changed "
     SERVICES=($(find . -name main.go | cut -c 3- | rev | cut -c 9- | rev))


### PR DESCRIPTION
Sometimes the added/modified services list coming from github action is legitimately empty, but the build workflow thinks it's because from a fork PR (when that happens). 