### PR TITLE
Minor tweaks and feedback

### DIFF
--- a/docs/web/content/pages/getting-started.md
+++ b/docs/web/content/pages/getting-started.md
@@ -48,6 +48,8 @@ First, we have to start the `micro server`. The command to do that is:
 micro server
 ```
 
+If all goes well you'll see log output from the various services initialising; this terminal will continue to output logs as we go through the rest of the tutorial so keep it running.
+
 To talk to this server, we just have to tell Micro CLI to address our server instead of using the default implementations - micro can work without a server too, but [more about that later](#-environments).
 
 The following command tells the CLI to talk to our server:
@@ -375,7 +377,7 @@ We are almost done! But first we have to learn how to update a service.
 
 Now since the example service is running (can be easily verified by `micro status`), we should not use `micro run`, but rather `micro update` to deploy it.
 
-We can simply issue
+We can simply issue the update command (remember to switch back to the root directory of the example service first)
 
 ```
 micro update .


### PR DESCRIPTION
Some `go` commands assume you're working under `GOPATH` while others need to be in a modules aware context. For example, the initial install command `go install github.com/micro/micro/v2` needs to run under GOPATH. Whereas the protoc install uses syntax that has to be done from a module 
```
go get github.com/micro/micro/v2/cmd/protoc-gen-micro@master
go: cannot use path@version syntax in GOPATH mode
```

There's a warning when you run the protoc generation itself
```
protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/foobar/foobar.proto
2020/05/05 09:51:12 WARNING: Missing 'go_package' option in "proto/foobar/foobar.proto", please specify:
	option go_package = "proto/foobar;go_micro_service_foobar";
A future release of protoc-gen-go will require this be specified.
See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.
```
This might be confusing for some users who don't understand that it's just a warning and can be safely ignored.

See comments for further feedback