### PR TITLE
make location service multi-tenant

### DIFF
--- a/location/domain/domain.go
+++ b/location/domain/domain.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	mtx          sync.RWMutex
-	defaultIndex = geo.NewPointsIndex(geo.Km(100))
+	defaultIndex = geo.NewPointsIndex(geo.Meters(100))
 
 	// index per tenant
 	indexes = map[string]*geo.PointsIndex{}

--- a/location/subscriber/subscriber.go
+++ b/location/subscriber/subscriber.go
@@ -16,6 +16,6 @@ type Location struct{}
 
 func (g *Location) Handle(ctx context.Context, e *proto.Entity) error {
 	log.Printf("Saving entity ID %s", e.Id)
-	domain.Save(domain.ProtoToEntity(e))
+	domain.Save(ctx, domain.ProtoToEntity(e))
 	return nil
 }


### PR DESCRIPTION
Uses a geoindex per tenant. All still in memory.

Ultimately we probably want to move to an LRU based model of storing in memory indexes, and then back that by the store. So full index gets stored in the database. Pull out when a change needs to be made or search has to happen. Recurrent access means fast access, anything else gets dropped.