### PR TITLE
Add curl examples

### DIFF
--- a/cmd/clients/go_template.go
+++ b/cmd/clients/go_template.go
@@ -70,3 +70,8 @@ import(
 	fmt.Println(rsp, err)
 }
 `
+
+const curlExampleTemplate = `curl "https://api.m3o.com/v1/{{ $service.Name }/{{ title .endpoint }}" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $MICRO_API_TOKEN" \
+-d '{{ tsExampleRequest $service.Name .endpoint $service.Spec.Components.Schemas .example.Request }}'`

--- a/cmd/clients/go_template.go
+++ b/cmd/clients/go_template.go
@@ -71,7 +71,7 @@ import(
 }
 `
 
-const curlExampleTemplate = `curl "https://api.m3o.com/v1/{{ $service.Name }/{{ title .endpoint }}" \
+const curlExampleTemplate = `{{ $service := .service }}curl "https://api.m3o.com/v1/{{ $service.Name }}/{{ title .endpoint }}" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $MICRO_API_TOKEN" \
 -d '{{ tsExampleRequest $service.Name .endpoint $service.Spec.Components.Schemas .example.Request }}'`

--- a/cmd/clients/main.go
+++ b/cmd/clients/main.go
@@ -361,7 +361,7 @@ func main() {
 							"funcName": strcase.UpperCamelCase(title),
 						})
 
-						curlExampleFile := filepath.Join(tsPath, serviceName, "examples", endpoint, title+".sh")
+						curlExampleFile := filepath.Join(goPath, serviceName, "examples", endpoint, title+".sh")
 						f, err = os.OpenFile(curlExampleFile, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0744)
 						if err != nil {
 							fmt.Println("Failed to open schema file", err)

--- a/cmd/clients/main.go
+++ b/cmd/clients/main.go
@@ -334,6 +334,35 @@ func main() {
 							fmt.Println(fmt.Sprintf("Problem with '%v' example '%v': %v", serviceName, endpoint, string(outp)))
 							os.Exit(1)
 						}
+
+						// curl example
+						templ, err = template.New("curl" + serviceName + endpoint).Funcs(funcs).Parse(curlExampleTemplate)
+						if err != nil {
+							fmt.Println("Failed to unmarshal", err)
+							os.Exit(1)
+						}
+						b = bytes.Buffer{}
+						buf = bufio.NewWriter(&b)
+						err = templ.Execute(buf, map[string]interface{}{
+							"service":  service,
+							"example":  example,
+							"endpoint": endpoint,
+							"funcName": strcase.UpperCamelCase(title),
+						})
+
+						curlExampleFile := filepath.Join(tsPath, serviceName, "examples", endpoint, title+".sh")
+						f, err = os.OpenFile(curlExampleFile, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0744)
+						if err != nil {
+							fmt.Println("Failed to open schema file", err)
+							os.Exit(1)
+						}
+
+						buf.Flush()
+						_, err = f.Write(b.Bytes())
+						if err != nil {
+							fmt.Println("Failed to append to schema file", err)
+							os.Exit(1)
+						}
 					}
 					// only build after each example is generated as old files from
 					// previous generation might not compile


### PR DESCRIPTION
We could generate this on the frontend given it's rather simple to construct but I thought why not follow conventions.

Save them next to the go one, because why not.