### PR TITLE
BugFix: if name == "" should return the prefix key

### DIFF
--- a/rss/handler/rss.go
+++ b/rss/handler/rss.go
@@ -33,9 +33,9 @@ func generateFeedKey(ctx context.Context, name string) string {
 		tenantID = "micro"
 	}
 
-	feedId := feedIdFromName(name)
-	if name == "" {
-		feedId = ""
+	var feedId string
+	if name != "" {
+		feedId = feedIdFromName(name)
 	}
 
 	return fmt.Sprintf("rss/feed/%s/%s", tenantID, feedId)

--- a/rss/handler/rss.go
+++ b/rss/handler/rss.go
@@ -109,6 +109,7 @@ func (e *Rss) Feed(ctx context.Context, req *pb.FeedRequest, rsp *pb.FeedRespons
 		req.Limit = int64(25)
 	}
 
+	var enough bool
 	for _, v := range records {
 		// decode feed
 		feed := pb.Feed{}
@@ -133,9 +134,14 @@ func (e *Rss) Feed(ctx context.Context, req *pb.FeedRequest, rsp *pb.FeedRespons
 			}
 
 			rsp.Entries = append(rsp.Entries, &entry)
+
+			if len(rsp.Entries) >= int(req.Limit) {
+				enough = true
+				break
+			}
 		}
 
-		if len(rsp.Entries) >= int(req.Limit) {
+		if enough {
 			break
 		}
 	}

--- a/rss/handler/rss.go
+++ b/rss/handler/rss.go
@@ -33,7 +33,12 @@ func generateFeedKey(ctx context.Context, name string) string {
 		tenantID = "micro"
 	}
 
-	return fmt.Sprintf("rss/feed/%s/%s", tenantID, feedIdFromName(name))
+	feedId := feedIdFromName(name)
+	if name == "" {
+		feedId = ""
+	}
+
+	return fmt.Sprintf("rss/feed/%s/%s", tenantID, feedId)
 }
 
 func NewRss(st store.Store, cr Crawler) *Rss {


### PR DESCRIPTION
1. Without the condition,  if name is empty string, the key always be `rss/feed/micro/admin/14695981039346656037`，
So the `List()` which use `prefix` to search will return `[]`
2. fix limit is not working