### PR TITLE
Add missing '&'

### DIFF
--- a/user/domain/domain.go
+++ b/user/domain/domain.go
@@ -499,14 +499,16 @@ func (domain *Domain) CacheReadToken(ctx context.Context, token string) (string,
 
 	var email string
 
-	expires, err := cache.Context(ctx).Get(token, email)
+	expires, err := cache.Context(ctx).Get(token, &email)
 
 	if err != nil && err == cache.ErrNotFound {
 		return "", errors.New("token not found")
-	} else if time.Until(expires).Seconds() < 0 {
-		return "", errors.New("token expired")
 	} else if err != nil {
 		return "", microerr.InternalServerError("CacheReadToken", err.Error())
+	}
+
+	if time.Until(expires).Seconds() < 0 {
+		return "", errors.New("token expired")
 	}
 
 	return email, nil


### PR DESCRIPTION
Add missing '&' to `email`  in the `Get` method