### PR TITLE
store house cleaning

### DIFF
--- a/user/domain/domain.go
+++ b/user/domain/domain.go
@@ -369,6 +369,7 @@ func (domain *Domain) Delete(ctx context.Context, userId string) error {
 		generateAccountStoreKey(ctx, userId),
 		generateAccountEmailStoreKey(ctx, account.Email),
 		generateAccountUsernameStoreKey(ctx, account.Username),
+		generatePasswordStoreKey(ctx, userId),
 	}
 
 	return domain.batchDelete(keys)


### PR DESCRIPTION
Currently `domain.Delete` doesn’t delete the associated password.
unless the intended behavior is to keep passwords this PR fixes that.
