### PR TITLE
Proto Update: Avatar, YouTube

### DIFF
--- a/avatar/proto/avatar.proto
+++ b/avatar/proto/avatar.proto
@@ -9,22 +9,21 @@ service Avatar {
 }
 
 message GenerateRequest {
-  // avatar's gender, `male` or `female`, default is `male`
+  // avatar's gender: `male` or `female`; default is `male`
   string gender = 1;
-  // avatar's username, unique username will generates the unique avatar;
-  // if username == "", will generate a random avatar in every request
-  // if upload == true, username will be used as CDN filename rather than a random uuid string
+  // avatar's username, unique username will generate the unique avatar;
+  // if empty, every request generates a random avatar;
+  // if upload == true, username will be the CDN filename rather than a random uuid string
   string username = 2;
-  // encode format of avatar image, `png` or `jpeg`, default is `jpeg`
+  // encode format of avatar image: `png` or `jpeg`; default is `jpeg`
   string format = 3;
-  // if upload to m3o CDN, default is `false`
-  // if update = true, then it'll return the CDN url
+  // set to true to upload to the M3O CDN and receive the url
   bool upload = 4;
 }
 
 message GenerateResponse {
-  // Micro's CDN url of the avatar image
+  // M3O's CDN url of the avatar image
   string url = 1;
-  // base64encode string of the avatar image
+  // base64 encoded string of the avatar image
   string base64 = 2;
 }

--- a/youtube/proto/youtube.proto
+++ b/youtube/proto/youtube.proto
@@ -11,7 +11,7 @@ service Youtube {
 
 // Embed a YouTube video
 message EmbedRequest {
-	// provide the youtube url e.g https://www.youtube.com/watch?v=GWRWZu7XsJ0
+	// provide the youtube url
 	string url = 1;
 }
 
@@ -20,7 +20,7 @@ message EmbedResponse {
 	string long_url = 1;
 	// the short url
 	string short_url = 2;
-	// the embeddable link e.g https://www.youtube.com/watch?v=GWRWZu7XsJ0
+	// the embeddable link
 	string embed_url = 3;
 	// the script code
 	string html_script = 4;
@@ -29,7 +29,7 @@ message EmbedResponse {
 message SearchResult {
 	// id of the result
 	string id = 1;
-	// kind of result; "video", "channel", "playlist"
+	// kind of result: "video", "channel", "playlist"
 	string kind = 2;
 	// title of the result
 	string title = 3;
@@ -41,7 +41,7 @@ message SearchResult {
 	string channel_title = 6;
 	// published at time
 	string published_at = 7;
-	// if live broadcast then indicates activity. 
+	// if live broadcast then indicates activity: 
 	// none, upcoming, live, completed
 	string broadcasting = 8;
 	// the associated url


### PR DESCRIPTION
As mentioned here are some small proto updates:

**Avatar**
Shorten texts, correct mistakes, replace Micro with M3O, set colons

**YouTube**
Remove example links (as you can see them in the example requests), set colons