### PR TITLE
add new initiatePublishApi workflow and rename downstream to initiate…

### DIFF
--- a/.github/workflows/initiateGenerator.yml
+++ b/.github/workflows/initiateGenerator.yml
@@ -1,6 +1,5 @@
-name: Downstream
+name: Initiate Generator
 
-# Alert downstream repos
 # [service].proto and examples.json are the only files that affect how the m3o clients generator 
 # will generate clients. Any internal changes to the service or how the service is implemented 
 # internally is not a concern and will not affect how internally m3o clients work.
@@ -10,17 +9,18 @@ on:
     paths:
       - '**.proto'
       - '**/examples.json'
-      - '**/publicapi.json'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # triggering m3o/m3o/.github/workflows/generate.yml (old generator)
       - name: Alert M3O
         run: |
           curl -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/m3o/m3o/dispatches -d '{"event_type":"micro_services"}'
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
-
+      #  triggering m3o/m3o/.github/workflows/scheduler.yml (new generator)
       - name: Alert M3O scheduler
         run: |
           curl -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/m3o/m3o/dispatches -d '{"event_type":"build_m3o_client"}'

--- a/.github/workflows/initiatePublishApi.yml
+++ b/.github/workflows/initiatePublishApi.yml
@@ -1,0 +1,19 @@
+name: Initiate Public API Publisher
+
+on:
+  push:
+    paths:
+      - '**.proto'
+      - '**/examples.json'
+      - '**/publicapi.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # triggering m3o/m3o/.github/workflows/publishapi.yml
+      - name: Initiate API Publisher
+        run: |
+          curl -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/m3o/m3o/dispatches -d '{"event_type":"public_api_publisher"}'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
1. Renamed _downstream.yml_ to _initiateGenerator.yml_
2. Removed one path `'**/publicapi.json'` from _initiateGenerator.yml_
3. Added new workflow _initiatePublishApi.yml_ to trigger _m3o/m3o/.github/workflows/publishapi.yml_

**note: there is another PR in m3o/m3o** 