### PR TITLE
fix example in the comments service

### DIFF
--- a/comments/examples.json
+++ b/comments/examples.json
@@ -5,7 +5,7 @@
         "description": "Create a simple text based comment",
         "run_check": false,
         "request": {
-            "title": "New Comment",
+            "subject": "New Comment",
             "text": "This is my comment"
         },
         "response": {


### PR DESCRIPTION
In the example titled "**Create a comment"** we use a wrong  attribute name _title_ instead of _subject_  as mentioned in the proto file https://github.com/micro/services/blob/310147c9e173455f81a89ad1893fa17e23b857cb/comments/proto/comments.proto#L32