### PR TITLE
Update API examples

### DIFF
--- a/id/examples.json
+++ b/id/examples.json
@@ -1,7 +1,7 @@
 {
   "generate": [
     {
-      "title": "Generate a unique ID",
+      "title": "Generate an universally unique ID",
       "run_check": true,
       "request": {
         "type": "uuid"
@@ -9,6 +9,39 @@
       "response": {
         "type": "uuid",
         "id": "e9c427d8-cef1-48bd-ab89-59a6df29673b"
+      }
+    },
+    {
+      "title": "Generate an unique lexicographically ID",
+      "run_check": true,
+      "request": {
+        "type": "ulid"
+      },
+      "response": {
+        "type": "ulid",
+        "id": "01G81FHTX562P4HD0SD3SZM1PA"
+      }
+    },
+    {
+      "title": "Generate an unique k-sortable ID",
+      "run_check": true,
+      "request": {
+        "type": "ksuid"
+      },
+      "response": {
+        "type": "ksuid",
+        "id": "2BzSAIfCKDTb9lY6ZQ8vekYIVHT"
+      }
+    },
+    {
+      "title": "Generate a web-oriented globally unique ID",
+      "run_check": true,
+      "request": {
+        "type": "xid"
+      },
+      "response": {
+        "type": "xid",
+        "id": "cb8qgv24hjve3rmushhg"
       }
     },
     {
@@ -51,7 +84,15 @@
       "run_check": false,
       "request": {},
       "response": {
-        "types": ["uuid", "shortid", "snowflake", "bigflake"]
+        "types": [
+            "uuid",
+            "ulid",
+            "ksuid",
+            "xid",
+            "shortid",
+            "snowflake",
+            "bigflake"
+        ]
       }
     }
   ]

--- a/id/examples.json
+++ b/id/examples.json
@@ -45,6 +45,17 @@
       }
     },
     {
+      "title": "Generate a URL-friendly unique ID",
+      "run_check": true,
+      "request": {
+        "type": "nanoid"
+      },
+      "response": {
+        "type": "nanoid",
+        "id": "yznF-9wXo0URikYX10XMv"
+      }
+    },
+    {
       "title": "Generate a short ID",
       "run_check": true,
       "request": {
@@ -89,6 +100,7 @@
             "ulid",
             "ksuid",
             "xid",
+            "nanoid",
             "shortid",
             "snowflake",
             "bigflake"

--- a/id/proto/id.proto
+++ b/id/proto/id.proto
@@ -11,7 +11,7 @@ service Id {
 
 // Generate a unique ID. Defaults to uuid.
 message GenerateRequest {
-	// type of id e.g uuid, shortid, snowflake (64 bit), bigflake (128 bit)
+	// type of id; call 'Types' endpoint for available types
 	string type = 1;
 }
 
@@ -22,7 +22,7 @@ message GenerateResponse {
 	string type = 2;
 }
 
-// List the types of IDs available. No query params needed.
+// List the types of IDs available.
 message TypesRequest {}
 
 message TypesResponse {

--- a/lists/examples.json
+++ b/lists/examples.json
@@ -5,7 +5,7 @@
         "description": "Create a simple text based list",
         "run_check": false,
         "request": {
-            "title": "New List",
+            "name": "New List",
             "items": ["This is my list"]
         },
         "response": {
@@ -13,7 +13,7 @@
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
                 "created": "2021-09-29T13:33:03+01:00",
                 "updated": "2021-09-29T13:33:03+01:00",
-                "title": "New List",
+                "name": "New List",
                 "items": ["This is my list"]
             }
         }
@@ -30,8 +30,8 @@
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
                 "created": "2021-09-29T13:33:03+01:00",
                 "updated": "2021-09-29T13:33:03+01:00",
-                "title": "New List",
-                "text": "This is my list"
+                "name": "New List",
+                "items": ["This is my list"]
             }
         }
     }],
@@ -43,11 +43,11 @@
         "response": {
             "lists": [
                 {
-                        "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
-                        "created": "2021-09-29T13:33:03+01:00",
-                        "updated": "2021-09-29T13:33:03+01:00",
-                        "title": "New List",
-                        "items": ["This is my list"]
+                    "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
+                    "created": "2021-09-29T13:33:03+01:00",
+                    "updated": "2021-09-29T13:33:03+01:00",
+                    "name": "New List",
+                    "items": ["This is my list"]
                 }
             ]
         }
@@ -59,7 +59,7 @@
         "request": {
 	    "list": {
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
-                "title": "Update List",
+                "name": "Update List",
                 "items": ["Updated list text"]
             }
         },
@@ -68,7 +68,7 @@
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
                 "created": "2021-09-29T13:33:03+01:00",
                 "updated": "2021-09-29T13:50:20+01:00",
-                "title": "Update List",
+                "name": "Update List",
                 "items": ["Updated list text"]
             }
         }
@@ -85,7 +85,7 @@
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
                 "created": "2021-09-29T13:33:03+01:00",
                 "updated": "2021-09-29T13:50:20+01:00",
-                "title": "Update List",
+                "name": "Update List",
                 "items": ["Updated list text"]
             }
         }
@@ -103,7 +103,7 @@
                 "id": "63c0cdf8-2121-11ec-a881-0242e36f037a",
                 "created": "2021-09-29T13:33:03+01:00",
                 "updated": "2021-09-29T13:50:20+01:00",
-                "title": "Update List",
+                "name": "Update List",
                 "items": ["Updated list text"]
             }
         }


### PR DESCRIPTION
I updated the list examples once again, because some entries were still wrong.

Another thing I found is the proxy function for URLs:
The description for the parameter `shortURL` is 

```
short url ID, without the domain, eg. if your short URL is `m3o.one/u/someshorturlid` then pass in `someshorturlid`
```

But the example request is 

```
-d '{
  "shortURL": "https://m3o.one/u/ck6SGVkYp"
}'
```

I mean it works but you don't use only the ID as described in the parameter description, should we change it?